### PR TITLE
Bump rails version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,39 +2,52 @@ PATH
   remote: .
   specs:
     redirect_safely (1.0.0)
-      activemodel
+      activemodel (>= 6.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (3.2.22.5)
-      activesupport (= 3.2.22.5)
-      builder (~> 3.0.0)
-    activesupport (3.2.22.5)
-      i18n (~> 0.6, >= 0.6.4)
-      multi_json (~> 1.0)
+    activemodel (8.1.1)
+      activesupport (= 8.1.1)
+    activesupport (8.1.1)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      json
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     ast (2.4.2)
-    builder (3.0.4)
-    byebug (11.1.1)
-    coderay (1.1.2)
-    concurrent-ruby (1.1.6)
-    i18n (0.9.5)
+    base64 (0.3.0)
+    bigdecimal (3.3.1)
+    byebug (12.0.0)
+    coderay (1.1.3)
+    concurrent-ruby (1.3.5)
+    connection_pool (2.5.4)
+    drb (2.2.3)
+    i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
-    method_source (0.9.2)
-    multi_json (1.14.1)
+    logger (1.7.0)
+    method_source (1.1.0)
+    minitest (5.26.0)
     parallel (1.24.0)
     parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
     power_assert (1.1.6)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
-    pry-byebug (3.8.0)
-      byebug (~> 11.0)
-      pry (~> 0.10)
+    pry (0.15.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.11.0)
+      byebug (~> 12.0)
+      pry (>= 0.13, < 0.16)
     racc (1.7.3)
     rainbow (3.1.1)
     rake (13.0.1)
@@ -54,15 +67,19 @@ GEM
     rubocop-ast (1.31.2)
       parser (>= 3.3.0.4)
     ruby-progressbar (1.13.0)
+    securerandom (0.4.1)
     test-unit (3.3.5)
       power_assert
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
+    uri (1.0.4)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (~> 3.0)
+  activesupport (>= 6.0)
   bundler (~> 2.5)
   pry-byebug
   rake

--- a/lib/redirect_safely.rb
+++ b/lib/redirect_safely.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "version"
+require "active_model"
 require "redirect_safely_validator"
 
 module RedirectSafely

--- a/lib/redirect_safely_validator.rb
+++ b/lib/redirect_safely_validator.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'active_model/validations'
 
 class RedirectSafelyValidator < ::ActiveModel::EachValidator
   def validate_each(record, attribute, value)

--- a/redirect_safely.gemspec
+++ b/redirect_safely.gemspec
@@ -27,9 +27,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activemodel'
+  spec.add_dependency 'activemodel', '>= 6.0'
 
-  spec.add_development_dependency 'activesupport', '~>3.0'
+  spec.add_development_dependency 'activesupport', '>= 6.0'
   spec.add_development_dependency 'test-unit', '~>3.0'
 
   spec.add_development_dependency 'bundler', '~> 2.5'


### PR DESCRIPTION
This brings this gem up-to-date with a more moden version of rails and avoids including activemodel files directly in favor of including the module.