### PR TITLE
Update REXML to 3.4.4 and migrate to minitest

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,6 @@ GEM
     parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
-    power_assert (1.1.6)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -52,7 +51,7 @@ GEM
     rainbow (3.1.1)
     rake (13.0.1)
     regexp_parser (2.9.0)
-    rexml (3.2.6)
+    rexml (3.4.4)
     rubocop (1.62.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -68,8 +67,6 @@ GEM
       parser (>= 3.3.0.4)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
-    test-unit (3.3.5)
-      power_assert
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
@@ -81,11 +78,11 @@ PLATFORMS
 DEPENDENCIES
   activesupport (>= 6.0)
   bundler (~> 2.5)
+  minitest
   pry-byebug
   rake
   redirect_safely!
   rubocop
-  test-unit (~> 3.0)
 
 BUNDLED WITH
    2.5.7

--- a/redirect_safely.gemspec
+++ b/redirect_safely.gemspec
@@ -30,8 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activemodel', '>= 6.0'
 
   spec.add_development_dependency 'activesupport', '>= 6.0'
-  spec.add_development_dependency 'test-unit', '~>3.0'
+  spec.add_development_dependency 'minitest'
 
   spec.add_development_dependency 'bundler', '~> 2.5'
-  spec.add_development_dependency 'rake', '~> 10.0'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,4 +6,5 @@ require 'active_model/naming'
 require 'active_model/translation'
 require 'redirect_safely'
 require 'redirect_safely_validator'
-require 'pry'
+
+require "active_support/testing/autorun"


### PR DESCRIPTION
### What are you trying to accomplish in this PR?

Update REXML from 3.2.6 to 3.4.4 and migrate test framework from test-unit to minitest. The test framework migration removes deprecated test-unit in favor of minitest, which is the standard Rails testing framework.

### How did you accomplish this and why did you choose this approach?

Updated `redirect_safely.gemspec` to replace `test-unit ~>3.0` with `minitest` as a development dependency. Updated REXML to 3.4.4 via Gemfile.lock. Modified `test/test_helper.rb` to require `active_support/testing/autorun` instead of loading pry, which properly initializes the minitest test runner. This approach keeps the gem aligned with standard Rails testing conventions.
