### PR TITLE
Add license information to gemspec

### DIFF
--- a/redirect_safely.gemspec
+++ b/redirect_safely.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |spec|
   spec.version       = RedirectSafely::VERSION
   spec.authors       = ['Shopify']
   spec.email         = ['gems@shopify.com']
+  spec.license       = 'MIT'
 
   spec.summary       = %q{Sanitize redirect_to URLs}
   spec.description   = %q{Sanitize redirect_to URLs}


### PR DESCRIPTION
This PR adds license metadata to the gemspec so the license metadata will populate properly in RubyGems and work with dependency auditing tools. I assume MIT is correct based on https://github.com/Shopify/redirect_safely/blob/master/LICENSE.md.