### PR TITLE
Reject URLs with a scheme but no host

### DIFF
--- a/lib/redirect_safely.rb
+++ b/lib/redirect_safely.rb
@@ -24,6 +24,7 @@ module RedirectSafely
       return false if uri.path =~ %r{[/\\][/\\]}
     end
     return false unless uri.scheme.nil? || ['http', 'https'].include?(uri.scheme)
+    return false if uri.scheme && uri.host.to_s.empty?
     return false unless uri.userinfo.nil?
     return false if options[:path_match] &&
     (uri.path !~ options[:path_match] || File.absolute_path(uri.path) !~ options[:path_match])

--- a/test/redirect_safely_test.rb
+++ b/test/redirect_safely_test.rb
@@ -149,6 +149,14 @@ class RedirectSafelyTest < ActiveSupport::TestCase
     refute RedirectSafely.safe?("https:///google.com")
   end
 
+  test "safe? returns false for scheme with a single slash (browsers normalize to authority)" do
+    refute RedirectSafely.safe?("http:/evil.com")
+    refute RedirectSafely.safe?("https:/evil.com")
+    refute RedirectSafely.safe?("http:/evil.com/path")
+    refute RedirectSafely.safe?("http:/evil.com", whitelist: ["evil.com"])
+    refute RedirectSafely.safe?("http:/sub.test.com", subdomains: [".test.com"])
+  end
+
   test "safe? returns false for an invalid URI" do
     refute RedirectSafely.safe?("http://goo<gle.com")
   end


### PR DESCRIPTION
A URL like `http:/evil.com` parses under RFC 3986 (Ruby's URI) as scheme="http", host=nil, path="/evil.com", and previously passed validation because `valid_host?` treats host=nil as trusted. Browsers implement the WHATWG URL Standard, which normalizes `http:/evil.com` to `http://evil.com/` for special schemes — so a 302 Location header with the former value would redirect to the attacker's origin.

Reject any URL that has a scheme but no host before we reach the host check. Paths without a scheme (e.g. `/a/b/c`) are unaffected.