### PR TITLE
Bump version to 1.0.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    redirect_safely (1.0.0)
+    redirect_safely (1.0.1)
       activemodel (>= 6.0)
 
 GEM

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module RedirectSafely
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
## Summary
- Bumps gem version from 1.0.0 to 1.0.1 for release
- Includes security fix from #14 that rejects URLs with a scheme but no host (e.g. `http:/evil.com`), which browsers normalize to authority-based URLs and can enable open-redirect bypass